### PR TITLE
Added a required class to form output

### DIFF
--- a/core/core-forms.php
+++ b/core/core-forms.php
@@ -283,6 +283,11 @@ class AF_Core_Forms {
 					
 					$attributes['class'] .= sprintf( ' af-field af-field-type-%s af-field-%s acf-field acf-field-%s acf-field-%s', $field['type'], $field['name'], $field['type'], $field['key'] );
 					
+					if($field['required']){
+						$attributes['class'] .= " af-field-required";
+					};
+
+					
 					// This is something ACF needs
 					$attributes['class'] = str_replace( '_', '-', $attributes['class'] );
 					$attributes['class'] = str_replace( 'field-field-', 'field-', $attributes['class'] );


### PR DESCRIPTION
Needed to see which fields were required on the frontend. Now "af-field-required" is appended to $attributes['class'] if the field is required.