### PR TITLE
Fixed undefined index

### DIFF
--- a/acf/acf-additions.php
+++ b/acf/acf-additions.php
@@ -59,10 +59,12 @@ class AF_ACF_Additions {
 		// Match with form object
 		if ( 'af_form' == $rule['param'] && isset( $options['af_form'] ) ) {
 			
-			if ( $rule['value'] == $options['af_form'] ) {
+			if( isset($rule['value'] ) ){
+				if ( $rule['value'] == $options['af_form'] ) {
 				
-				$match = true;
+					$match = true;
 				
+				}
 			}
 			
 		}


### PR DESCRIPTION
I was getting an undefined index warning that was popping up in multiple places with debug turned on.

<img width="795" alt="screen shot 2017-03-31 at 20 37 59" src="https://cloud.githubusercontent.com/assets/1636310/24569929/ab484d00-1660-11e7-8b59-094a3307edb7.png">
<img width="1097" alt="screen shot 2017-03-31 at 20 52 35" src="https://cloud.githubusercontent.com/assets/1636310/24569930/ab4c3e4c-1660-11e7-89fe-b5b3cd4c7ca8.png">

Just added an "isset" to stop this.
