### PR TITLE
Ability to exclude fields on a per form render

### DIFF
--- a/core/core-forms.php
+++ b/core/core-forms.php
@@ -146,6 +146,7 @@ class AF_Core_Forms {
 			'submit_text' 				=> __( 'Submit', 'advanced-forms' ),
 			'redirect' 					=> add_query_arg( 'af_succcess', '', $url ),
 			'echo'						=> true,
+			'exclude_fields'			=> array(), // pass field keys here
 		));
 		
 		
@@ -260,6 +261,14 @@ class AF_Core_Forms {
 				
 				foreach ( $fields as $field ) {
 					
+					// See if the excluded fields arg is present and there is at least 1 key
+					if ( $args['exclude_fields'] && count($args['exclude_fields']) > 0 ) {
+						// Check to see if the field has been excluded
+						if( in_array( $field['key'], $args['exclude_fields'] ) ){
+							continue; // Skip the main field forloop because this field is excluded
+						}
+					}
+
 					// Check if we have any prefilled values for this field, either in the args or previously submitted
 					if ( isset( $_POST['acf'][ $field['key'] ] ) ) {
 					


### PR DESCRIPTION
So... I've actually used this twice (on two separate sites) this week. I have a signup form that includes:

- First Name
- Last Name
- Email
- Another ACF field 1
- Another ACF field 2
- Another ACF field 3
- Another ACF field 4

These fields are saved in an ACF field group that is then assigned to a user 'signup form' and a 'profile edit form'.

When a user signs up and the form gets processed, I create a new user and allocate the crucial data (First Name, Last Name and Email) to the actual user account, and the other fields just to standard custom field on the user.

Once the user is signed up, there is an edit form on their profile. I do not want them to edit their email address assigned to their account. So I can pass the field reference into the 'exclude_fields' arg and that field is skipped from rendering and validation on just the edit form. Like:

```
$args = array(
    'exclude_fields'          => array('field_58deaec4485d3')			
);
					
advanced_form( 'form_58deb014ec477', $args );
```

Give it a spin and let me know your thoughts :)