### PR TITLE
Add action hooks before and after sending email

### DIFF
--- a/core/core-emails.php
+++ b/core/core-emails.php
@@ -176,8 +176,12 @@ class AF_Core_Emails {
 		$attachments = apply_filters( 'af/form/email/attachments/key=' . $form['key'], $attachments, $email, $form, $fields );
 		
 		
+		do_action( 'af/form/before_wp_mail', $email, $form, $fields );
+		
 		// Send email using wp_mail
 		wp_mail( $recipient, $subject, $html, $headers, $attachments );
+		
+		do_action( 'af/form/after_wp_mail', $email, $form, $fields );
 		
 	}
 	

--- a/core/core-emails.php
+++ b/core/core-emails.php
@@ -176,12 +176,16 @@ class AF_Core_Emails {
 		$attachments = apply_filters( 'af/form/email/attachments/key=' . $form['key'], $attachments, $email, $form, $fields );
 		
 		
-		do_action( 'af/form/before_wp_mail', $email, $form, $fields );
+		do_action( 'af/email/before_send', $email, $form, $fields );
+		do_action( 'af/email/before_send/id=' . $form['post_id'], $email, $form, $fields );
+		do_action( 'af/email/before_send/key=' . $form['key'] $email, $form, $fields );
 		
 		// Send email using wp_mail
 		wp_mail( $recipient, $subject, $html, $headers, $attachments );
 		
-		do_action( 'af/form/after_wp_mail', $email, $form, $fields );
+		do_action( 'af/email/after_send', $email, $form, $fields );
+		do_action( 'af/email/after_send/id=' . $form['post_id'], $email, $form, $fields );
+		do_action( 'af/email/after_send/key=' . $form['key'] $email, $form, $fields );
 		
 	}
 	


### PR DESCRIPTION
This allows third party script to execute action before the mail will be sent and afterwards. A use case would be to create and delete temporary files.