### PR TITLE
Render textarea fields same as wysiwyg fields in emails

### DIFF
--- a/api/api-helpers.php
+++ b/api/api-helpers.php
@@ -109,6 +109,11 @@ function _af_render_field_include( $field, $value = false ) {
 		// Output WYSIWYG content without sanitation
 		$output .= stripslashes( $value );
 
+	elseif ( 'textarea' == $field['type'] ) {
+
+		// Output textarea content without sanitation
+		$output .= stripslashes( $value );
+
 	} else {
 		
 		/**

--- a/api/api-helpers.php
+++ b/api/api-helpers.php
@@ -109,7 +109,7 @@ function _af_render_field_include( $field, $value = false ) {
 		// Output WYSIWYG content without sanitation
 		$output .= stripslashes( $value );
 
-	elseif ( 'textarea' == $field['type'] ) {
+	} elseif ( 'textarea' == $field['type'] ) {
 
 		// Output textarea content without sanitation
 		$output .= stripslashes( $value );

--- a/api/api-helpers.php
+++ b/api/api-helpers.php
@@ -104,15 +104,10 @@ function _af_render_field_include( $field, $value = false ) {
 
 		$output .= sprintf( '<a href="%s">%s</a>', $value['url'], htmlspecialchars( $value['title'] ) );
 
-	} elseif ( 'wysiwyg' == $field['type'] ) {
+	} elseif ( 'wysiwyg' == $field['type'] || 'textarea' == $field['type'] ) {
 
-		// Output WYSIWYG content without sanitation
-		$output .= stripslashes( $value );
-
-	} elseif ( 'textarea' == $field['type'] ) {
-
-		// Output textarea content without sanitation
-		$output .= stripslashes( $value );
+		// Sanitize input using kses
+		$output .= wp_kses_post( stripslashes( $value ) );
 
 	} else {
 		


### PR DESCRIPTION
Textarea field is very common for contact forms. The email notifications however display all characters of the textarea, including paragraphs and br. I think it's much better to output them as html.