### PR TITLE
Fix missing ID for honeypot field

### DIFF
--- a/core/forms/forms-rendering.php
+++ b/core/forms/forms-rendering.php
@@ -284,7 +284,7 @@ class AF_Core_Forms_Rendering {
       // Bots should hopefully fill this in allowing them to be detected.
       if ( $args['honeypot'] ) {
         echo '<label for="email_for_non_humans" aria-hidden="true">Email for non-humans</label>';
-        echo '<input type="text" name="email_for_non_humans" tabindex="-1" autocomplete="off" />';
+        echo '<input type="text" name="email_for_non_humans" id="email_for_non_humans" tabindex="-1" autocomplete="off" />';
       }
 
       // Add origin URL to enable an automatic redirect back to the form page after submission.

--- a/core/forms/forms-rendering.php
+++ b/core/forms/forms-rendering.php
@@ -282,9 +282,9 @@ class AF_Core_Forms_Rendering {
 
       // Add honeypot field that is not visible to users.
       // Bots should hopefully fill this in allowing them to be detected.
-      if ( $args['honeypot'] ) {
-        echo '<label for="email_for_non_humans" aria-hidden="true">Email for non-humans</label>';
-        echo '<input type="text" name="email_for_non_humans" id="email_for_non_humans" tabindex="-1" autocomplete="off" />';
+      if ( $args['honeypot'] ) {        
+        echo sprintf( '<label for="af_email_for_non_humans_%s" aria-hidden="true">Email for non-humans</label>', $form['key'] );
+        echo sprintf( '<input type="text" name="email_for_non_humans" id="af_email_for_non_humans_%s" tabindex="-1" autocomplete="off" />', $form['key'] );        
       }
 
       // Add origin URL to enable an automatic redirect back to the form page after submission.


### PR DESCRIPTION
The id attribute is required on the input field when adding a label