### PR TITLE
Add acf-input.js as dependency for admin script

### DIFF
--- a/advanced-forms.php
+++ b/advanced-forms.php
@@ -174,7 +174,7 @@ class AF {
 
 		wp_enqueue_script( 'jquery' );
 
-		wp_enqueue_script( 'af-admin-script', $this->url .  'assets/dist/js/admin.js', array( 'jquery' ) );
+		wp_enqueue_script( 'af-admin-script', $this->url .  'assets/dist/js/admin.js', array( 'jquery', 'acf-input' ) );
 
 	}
 


### PR DESCRIPTION
Set 'acf-input' as a dependency for the admin.js script so that the ACF not defined in wp-admin error does not happen.